### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests-toolbelt
 twine
 python-gitlab
 python-pptx
+pdfplumber


### PR DESCRIPTION
Hi @lea-33 ,

just a minor thing: When running the `Compare_Embeddings.ipynb` notebook on my machine, there was an error that `pdfplumber` is not installed.

With this PR, I'm just adding it to the requirements.

Best,
Robert
